### PR TITLE
[API/#23]: 회원 API 연동

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
   rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
     'react-refresh/only-export-components': [
       'warn',
       { allowConstantExport: true },

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,3 +1,4 @@
+import { TokenKey } from '@/constants/storage';
 import axios from 'axios';
 // const baseUrl = 'http://localhost:8888';
 const baseUrl = 'http://dev-hub.ap-northeast-2.elasticbeanstalk.com';
@@ -33,7 +34,7 @@ authInstance.interceptors.response.use(
 // authInstance 요청에 대한 interceptor -> 요청 직전 header에 access token 추가
 authInstance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('access_token');
+    const token = localStorage.getItem(TokenKey);
     config.headers['Authorization'] = `Bearer ${token}`;
     return config;
   },

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -12,6 +12,24 @@ export const authInstance = axios.create({
   baseURL: baseUrl,
 });
 
+baseInstance.interceptors.response.use(
+  (res) => {
+    return res;
+  },
+  (err) => {
+    return Promise.reject(err);
+  },
+);
+
+authInstance.interceptors.response.use(
+  (res) => {
+    return res;
+  },
+  (err) => {
+    return Promise.reject(err);
+  },
+);
+
 // authInstance 요청에 대한 interceptor -> 요청 직전 header에 access token 추가
 authInstance.interceptors.request.use(
   (config) => {

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,7 +1,7 @@
 import { TokenKey } from '@/constants/storage';
 import axios from 'axios';
-const baseUrl = 'http://localhost:8888';
-// const baseUrl = 'http://dev-hub.ap-northeast-2.elasticbeanstalk.com';
+// const baseUrl = 'http://localhost:8888';
+const baseUrl = 'http://dev-hub.ap-northeast-2.elasticbeanstalk.com';
 
 // token 인증이 필요 없는 요청
 export const baseInstance = axios.create({

--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -1,7 +1,7 @@
 import { TokenKey } from '@/constants/storage';
 import axios from 'axios';
-// const baseUrl = 'http://localhost:8888';
-const baseUrl = 'http://dev-hub.ap-northeast-2.elasticbeanstalk.com';
+const baseUrl = 'http://localhost:8888';
+// const baseUrl = 'http://dev-hub.ap-northeast-2.elasticbeanstalk.com';
 
 // token 인증이 필요 없는 요청
 export const baseInstance = axios.create({

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -1,4 +1,4 @@
-import { JoinReq, LoginReq } from '@/types/api/request';
+import { JoinReq, LoginReq, RequestResetReq } from '@/types/api/request';
 import { authInstance, baseInstance } from './instance';
 import { AxiosResponse } from 'axios';
 import {
@@ -20,6 +20,8 @@ export const userAPI = {
     } catch (err: any) {
       if (err.response.status === 401) {
         return err.response.data;
+      } else {
+        window.alert('오류가 발생했습니다.');
       }
     }
   },
@@ -43,6 +45,21 @@ export const userAPI = {
       return data;
     } catch (err) {
       window.alert('오류가 발생했습니다.');
+    }
+  },
+  requestReset: async (userData: RequestResetReq) => {
+    try {
+      const { data }: AxiosResponse<CommonRes> = await baseInstance.post(
+        `/users/password`,
+        userData,
+      );
+      return data;
+    } catch (err: any) {
+      if (err.response.status === 403) {
+        return err.response.data;
+      } else {
+        window.alert('오류가 발생했습니다.');
+      }
     }
   },
   getUserInfo: async () => {

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -62,6 +62,21 @@ export const userAPI = {
       }
     }
   },
+  resetPassword: async (formData: LoginReq) => {
+    try {
+      const { data }: AxiosResponse<CommonRes> = await baseInstance.put(
+        `/users/password`,
+        formData,
+      );
+      return data;
+    } catch (err: any) {
+      if (err.response.status === 403) {
+        return err.response.data;
+      } else {
+        window.alert('오류가 발생했습니다.');
+      }
+    }
+  },
   getUserInfo: async () => {
     try {
       const { data }: AxiosResponse<UserInfoRes> = await authInstance.get(

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -1,10 +1,20 @@
 import { JoinReq, LoginReq } from '@/types/api/request';
-import { baseInstance } from './instance';
+import { authInstance, baseInstance } from './instance';
+import { AxiosResponse } from 'axios';
+import {
+  CommonRes,
+  EmailCheckRes,
+  LoginRes,
+  UserInfoRes,
+} from '@/types/api/response';
 
 export const userAPI = {
   login: async (user: LoginReq) => {
     try {
-      const { data } = await baseInstance.post(`/users/login`, user);
+      const { data }: AxiosResponse<LoginRes> = await baseInstance.post(
+        `/users/login`,
+        user,
+      );
       return data;
     } catch (err: any) {
       if (err.response.status === 401) {
@@ -14,7 +24,10 @@ export const userAPI = {
   },
   emailCheck: async (email: string) => {
     try {
-      const { data } = await baseInstance.post(`/users/check-email`, { email });
+      const { data }: AxiosResponse<EmailCheckRes> = await baseInstance.post(
+        `/users/check-email`,
+        { email },
+      );
       return data;
     } catch (err) {
       window.alert('오류가 발생했습니다.');
@@ -22,7 +35,20 @@ export const userAPI = {
   },
   join: async (formData: JoinReq) => {
     try {
-      const { data } = await baseInstance.post(`/users/join`, formData);
+      const { data }: AxiosResponse<CommonRes> = await baseInstance.post(
+        `/users/join`,
+        formData,
+      );
+      return data;
+    } catch (err) {
+      window.alert('오류가 발생했습니다.');
+    }
+  },
+  getUserInfo: async () => {
+    try {
+      const { data }: AxiosResponse<UserInfoRes> = await authInstance.get(
+        `/users`,
+      );
       return data;
     } catch (err) {
       window.alert('오류가 발생했습니다.');

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -6,8 +6,10 @@ export const userAPI = {
     try {
       const { data } = await baseInstance.post(`/users/login`, user);
       return data;
-    } catch (err) {
-      throw err;
+    } catch (err: any) {
+      if (err.response.status === 401) {
+        return err.response.data;
+      }
     }
   },
   emailCheck: async (email: string) => {
@@ -15,7 +17,7 @@ export const userAPI = {
       const { data } = await baseInstance.post(`/users/check-email`, { email });
       return data;
     } catch (err) {
-      throw err;
+      window.alert('오류가 발생했습니다.');
     }
   },
   join: async (formData: JoinReq) => {
@@ -23,7 +25,7 @@ export const userAPI = {
       const { data } = await baseInstance.post(`/users/join`, formData);
       return data;
     } catch (err) {
-      throw err;
+      window.alert('오류가 발생했습니다.');
     }
   },
 };

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -5,6 +5,7 @@ import {
   CommonRes,
   EmailCheckRes,
   LoginRes,
+  TopFiveRes,
   UserInfoRes,
 } from '@/types/api/response';
 
@@ -58,6 +59,16 @@ export const userAPI = {
     try {
       const { data }: AxiosResponse<CommonRes> = await authInstance.delete(
         `/users`,
+      );
+      return data;
+    } catch (err) {
+      window.alert('오류가 발생했습니다.');
+    }
+  },
+  getTopFive: async () => {
+    try {
+      const { data }: AxiosResponse<TopFiveRes[]> = await baseInstance.get(
+        `/users/top`,
       );
       return data;
     } catch (err) {

--- a/src/api/userAPI.ts
+++ b/src/api/userAPI.ts
@@ -54,4 +54,14 @@ export const userAPI = {
       window.alert('오류가 발생했습니다.');
     }
   },
+  deleteAccount: async () => {
+    try {
+      const { data }: AxiosResponse<CommonRes> = await authInstance.delete(
+        `/users`,
+      );
+      return data;
+    } catch (err) {
+      window.alert('오류가 발생했습니다.');
+    }
+  },
 };

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -37,16 +37,13 @@ const FindPasswordForm = () => {
   };
 
   const handleSubmitForm = async () => {
-    if (!form.email || !form.name) {
-      alert('값을 모두 입력해주세요.');
-      return;
-    }
-
     await userAPI
       .requestReset({ email: form.email, nickname: form.name })
       .then((res) => {
         if (res?.isSuccess) {
-          navigate(LOGIN_ROUTER_PATH.password.reset);
+          navigate(LOGIN_ROUTER_PATH.password.reset, {
+            state: { email: form.email },
+          });
         } else {
           window.alert('존재하지 않는 유저입니다.');
         }
@@ -81,7 +78,9 @@ const FindPasswordForm = () => {
       <SubmitContainer>
         <FormButton
           type='submit'
-          disabled={!FormRegex.email.test(form.email)}
+          disabled={
+            !FormRegex.email.test(form.email) || !form.email || !form.name
+          }
           text={'비밀번호 찾기'}
           onClick={() => {}}
         />

--- a/src/components/account/FindPasswordForm.tsx
+++ b/src/components/account/FindPasswordForm.tsx
@@ -12,6 +12,7 @@ import FormButton from '../common/FormInput/FormButton';
 import { Link, useNavigate } from 'react-router-dom';
 import { ICONS } from '@/assets/icon/icons';
 import { LOGIN_ROUTER_PATH } from '@/constants/path';
+import { userAPI } from '@/api/userAPI';
 
 interface FindPasswordForm {
   name: string;
@@ -35,8 +36,21 @@ const FindPasswordForm = () => {
     });
   };
 
-  const handleSubmitForm = () => {
-    navigate(LOGIN_ROUTER_PATH.password.reset);
+  const handleSubmitForm = async () => {
+    if (!form.email || !form.name) {
+      alert('값을 모두 입력해주세요.');
+      return;
+    }
+
+    await userAPI
+      .requestReset({ email: form.email, nickname: form.name })
+      .then((res) => {
+        if (res?.isSuccess) {
+          navigate(LOGIN_ROUTER_PATH.password.reset);
+        } else {
+          window.alert('존재하지 않는 유저입니다.');
+        }
+      });
   };
 
   return (
@@ -61,10 +75,16 @@ const FindPasswordForm = () => {
           regex={FormRegex.email}
           onChange={(e) => handleFormChange('email', e.target.value)}
           placeholder='이메일을 입력해주세요'
+          errorMessage='이메일 형식이 유효하지 않습니다'
         />
       </InputContainer>
       <SubmitContainer>
-        <FormButton type='submit' text={'비밀번호 찾기'} onClick={() => {}} />
+        <FormButton
+          type='submit'
+          disabled={!FormRegex.email.test(form.email)}
+          text={'비밀번호 찾기'}
+          onClick={() => {}}
+        />
         <GotoPage>
           <img src={ICONS.join} />
           <Link to={LOGIN_ROUTER_PATH.login}>{'로그인'}</Link>

--- a/src/components/account/JoinForm.tsx
+++ b/src/components/account/JoinForm.tsx
@@ -40,6 +40,9 @@ const JoinForm = () => {
     passwordCheck: '',
   });
 
+  const isEmpty =
+    !form.name || !form.email || !form.password || !form.passwordCheck;
+
   const handleFormChange = <T extends keyof JoinForm>(
     key: T,
     value: JoinForm[T],
@@ -139,12 +142,24 @@ const JoinForm = () => {
           value={form.passwordCheck}
           onChange={(e) => handleFormChange('passwordCheck', e.target.value)}
           placeholder='비밀번호를 한 번 더 입력해주세요'
-          isError={form.passwordCheck !== form.password}
+          isError={
+            Boolean(form.password && form.passwordCheck) &&
+            form.passwordCheck !== form.password
+          }
           errorMessage='비밀번호가 일치하지 않습니다'
         />
       </InputContainer>
       <SubmitContainer>
-        <FormButton type='submit' text={'회원가입'} onClick={() => {}} />
+        <FormButton
+          type='submit'
+          disabled={
+            isEmpty ||
+            form.passwordCheck !== form.password ||
+            !emailCheck.canUse
+          }
+          text={'회원가입'}
+          onClick={() => {}}
+        />
         <GotoPage>
           <img src={ICONS.join} />
           <Link to={LOGIN_ROUTER_PATH.login}>{'로그인'}</Link>

--- a/src/components/account/JoinForm.tsx
+++ b/src/components/account/JoinForm.tsx
@@ -14,7 +14,6 @@ import { Link, useNavigate } from 'react-router-dom';
 import { ICONS } from '@/assets/icon/icons';
 import { LOGIN_ROUTER_PATH } from '@/constants/path';
 import { userAPI } from '@/api/userAPI';
-import { CommonRes, EmailCheckRes } from '@/types/api/response';
 
 interface JoinForm {
   name: string;
@@ -66,8 +65,8 @@ const JoinForm = () => {
           email: form.email,
           password: form.password,
         })
-        .then((data: CommonRes) => {
-          if (data.isSuccess) {
+        .then((data) => {
+          if (data?.isSuccess) {
             alert('회원가입 되었습니다.');
             navigate('/account/login');
           }
@@ -76,8 +75,8 @@ const JoinForm = () => {
   };
 
   const handleCheckDuplicateClick = async () => {
-    await userAPI.emailCheck(form.email).then((data: EmailCheckRes) => {
-      if (data.result) {
+    await userAPI.emailCheck(form.email).then((data) => {
+      if (data?.result) {
         setEmailCheck({ canUse: true, message: '사용 가능한 이메일입니다' });
       } else {
         setEmailCheck({

--- a/src/components/account/JoinForm.tsx
+++ b/src/components/account/JoinForm.tsx
@@ -70,28 +70,22 @@ const JoinForm = () => {
           if (data.isSuccess) {
             alert('회원가입 되었습니다.');
             navigate('/account/login');
-          } else {
-            alert('회원가입을 실패했습니다.');
           }
-        })
-        .catch(() => alert('오류가 발생했습니다.'));
+        });
     }
   };
 
   const handleCheckDuplicateClick = async () => {
-    await userAPI
-      .emailCheck(form.email)
-      .then((data: EmailCheckRes) => {
-        if (data.result) {
-          setEmailCheck({ canUse: true, message: '사용 가능한 이메일입니다' });
-        } else {
-          setEmailCheck({
-            canUse: false,
-            message: '이미 사용 중인 이메일입니다',
-          });
-        }
-      })
-      .catch(() => alert('오류가 발생했습니다.'));
+    await userAPI.emailCheck(form.email).then((data: EmailCheckRes) => {
+      if (data.result) {
+        setEmailCheck({ canUse: true, message: '사용 가능한 이메일입니다' });
+      } else {
+        setEmailCheck({
+          canUse: false,
+          message: '이미 사용 중인 이메일입니다',
+        });
+      }
+    });
   };
 
   return (

--- a/src/components/account/LoginForm.tsx
+++ b/src/components/account/LoginForm.tsx
@@ -110,7 +110,11 @@ const LoginForm = () => {
         />
         <ButtonWrapper>
           <ErrorMessage>{error}</ErrorMessage>
-          <FormButton text={'로그인'} onClick={handleSubmitForm} />
+          <FormButton
+            text={'로그인'}
+            disabled={!form.email || !form.password}
+            onClick={handleSubmitForm}
+          />
         </ButtonWrapper>
         <GotoFindPassword>
           <Link to={LOGIN_ROUTER_PATH.password.find}>

--- a/src/components/account/LoginForm.tsx
+++ b/src/components/account/LoginForm.tsx
@@ -76,8 +76,7 @@ const LoginForm = () => {
         } else {
           setError('이메일 또는 비밀번호가 틀렸습니다');
         }
-      })
-      .catch(() => alert('로그인 중 오류가 발생했습니다.'));
+      });
   };
 
   return (

--- a/src/components/account/LoginForm.tsx
+++ b/src/components/account/LoginForm.tsx
@@ -16,7 +16,6 @@ import { LOGIN_ROUTER_PATH } from '@/constants/path';
 import { TokenKey, UserEmailKey, UserPasswordKey } from '@/constants/storage';
 import { userAPI } from '@/api/userAPI';
 import useStore from '@/store/store';
-import { LoginRes } from '@/types/api/response';
 
 interface LoginForm {
   email: string;
@@ -25,7 +24,7 @@ interface LoginForm {
 
 const LoginForm = () => {
   const navigate = useNavigate();
-  const { setUser } = useStore();
+  const { setUserId } = useStore();
   const [error, setError] = useState<string>('');
   const [form, setForm] = useState<LoginForm>({
     email: '',
@@ -61,9 +60,9 @@ const LoginForm = () => {
   const handleSubmitForm = async () => {
     await userAPI
       .login({ email: form.email, password: form.password })
-      .then((data: LoginRes) => {
+      .then((data) => {
         if (data.isSuccess) {
-          setUser(data.userId!);
+          setUserId(data.userId!);
           localStorage.setItem(TokenKey, data.accessToken!);
 
           // 로그인 정보 저장

--- a/src/components/account/ResetPasswordForm.tsx
+++ b/src/components/account/ResetPasswordForm.tsx
@@ -8,9 +8,10 @@ import {
 import FormInput from '../common/FormInput/FormInput';
 import { useState } from 'react';
 import FormButton from '../common/FormInput/FormButton';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { ICONS } from '@/assets/icon/icons';
 import { LOGIN_ROUTER_PATH } from '@/constants/path';
+import { userAPI } from '@/api/userAPI';
 
 interface ResetPasswordForm {
   password: string;
@@ -18,6 +19,10 @@ interface ResetPasswordForm {
 }
 
 const ResetPasswordForm = () => {
+  const navigate = useNavigate();
+  const {
+    state: { email },
+  } = useLocation();
   const [form, setForm] = useState<ResetPasswordForm>({
     password: '',
     passwordCheck: '',
@@ -33,7 +38,16 @@ const ResetPasswordForm = () => {
     });
   };
 
-  const handleSubmitForm = () => {};
+  const handleSubmitForm = async () => {
+    await userAPI
+      .resetPassword({ email: email, password: form.password })
+      .then((res) => {
+        if (res.isSuccess) {
+          alert('비밀번호가 정상적으로 재설정되었습니다.');
+          navigate(LOGIN_ROUTER_PATH.login);
+        }
+      });
+  };
 
   return (
     <FormRoot
@@ -49,7 +63,7 @@ const ResetPasswordForm = () => {
           type='password'
           value={form.password}
           onChange={(e) => handleFormChange('password', e.target.value)}
-          placeholder='회원님의 닉네임을 입력해주세요'
+          placeholder='비밀번호를 입력해주세요'
         />
         <FormInput
           id={'passwordCheck-input'}
@@ -57,11 +71,25 @@ const ResetPasswordForm = () => {
           value={form.passwordCheck}
           type='password'
           onChange={(e) => handleFormChange('passwordCheck', e.target.value)}
-          placeholder='이메일을 입력해주세요'
+          placeholder='비밀번호를 한 번 더 입력해주세요'
+          isError={
+            Boolean(form.password && form.passwordCheck) &&
+            form.passwordCheck !== form.password
+          }
+          errorMessage='비밀번호가 일치하지 않습니다'
         />
       </InputContainer>
       <SubmitContainer>
-        <FormButton type='submit' text={'비밀번호 재설정'} onClick={() => {}} />
+        <FormButton
+          type='submit'
+          disabled={
+            !form.password ||
+            !form.passwordCheck ||
+            form.passwordCheck !== form.password
+          }
+          text={'비밀번호 재설정'}
+          onClick={() => {}}
+        />
         <GotoPage>
           <img src={ICONS.join} />
           <Link to={LOGIN_ROUTER_PATH.login}>{'로그인'}</Link>

--- a/src/components/homePage/Profile.tsx
+++ b/src/components/homePage/Profile.tsx
@@ -1,27 +1,34 @@
 import styled from 'styled-components';
-import Lv5 from '@/assets/image/lv5.svg?react';
 import Button from '../common/Button';
 import { ICONS } from '@/assets/icon/icons';
 import { useNavigate } from 'react-router-dom';
+import useStore from '@/store/store';
+import { LEVEL } from '@/constants/level';
+
+type LevelKeys = keyof typeof LEVEL;
 
 function Profile() {
+  const { user } = useStore();
   const navigate = useNavigate();
+
+  const userLevel = LEVEL[user!.level as LevelKeys];
+
   return (
     <Wrapper>
       <h4>내 프로필</h4>
       <Container>
-        <Lv5 />
+        <img src={userLevel.icon} alt='level icon' width={80} height={80} />
         <UserInfo>
-          <h3>류지민</h3>
-          <span>Lv.5 개발자에게 밤샘은 기본</span>
+          <h3>{user!.nickname}</h3>
+          <span>{`${userLevel.level} ${userLevel.name}`}</span>
         </UserInfo>
         <ActivityInfo>
           <Activity>
-            <h4>19개</h4>
+            <h4>{user!.totalPosts}개</h4>
             <span>공유한 지식</span>
           </Activity>
           <Activity>
-            <h4>204점</h4>
+            <h4>{user!.totalPoints}점</h4>
             <span>보유 포인트</span>
           </Activity>
         </ActivityInfo>

--- a/src/components/homePage/Profile.tsx
+++ b/src/components/homePage/Profile.tsx
@@ -2,16 +2,13 @@ import styled from 'styled-components';
 import Button from '../common/Button';
 import { ICONS } from '@/assets/icon/icons';
 import { useNavigate } from 'react-router-dom';
+import { useLevel } from '@/hooks/useLevel';
 import useStore from '@/store/store';
-import { LEVEL } from '@/constants/level';
-
-type LevelKeys = keyof typeof LEVEL;
 
 function Profile() {
   const { user } = useStore();
+  const { userLevel } = useLevel();
   const navigate = useNavigate();
-
-  const userLevel = LEVEL[user!.level as LevelKeys];
 
   return (
     <Wrapper>

--- a/src/components/homePage/Top5.tsx
+++ b/src/components/homePage/Top5.tsx
@@ -1,16 +1,30 @@
-import styled from "styled-components";
-import TopUser from "./TopUser";
+import styled from 'styled-components';
+import TopUser from './TopUser';
+import { useEffect, useState } from 'react';
+import { TopFiveRes } from '@/types/api/response';
+import { userAPI } from '@/api/userAPI';
 
 function Top5() {
+  const [topFive, setTopFive] = useState<TopFiveRes[] | null>(null);
+
+  useEffect(() => {
+    const getTopFiveUser = async () => {
+      await userAPI.getTopFive().then((res) => {
+        if (res) {
+          setTopFive(res);
+        }
+      });
+    };
+    getTopFiveUser();
+  }, []);
+
   return (
     <Wrapper>
       <h4>지식 공유 Top5 수강생! 🔥</h4>
       <Container>
-        <TopUser rank={1} userName="류지민" points={204} />
-        <TopUser rank={2} userName="류지민" points={204} />
-        <TopUser rank={3} userName="류지민" points={204} />
-        <TopUser rank={4} userName="류지민" points={204} />
-        <TopUser rank={5} userName="류지민" points={204} />
+        {topFive?.map((user, i) => (
+          <TopUser rank={i + 1} userName={user.name} points={user.points} />
+        ))}
       </Container>
     </Wrapper>
   );

--- a/src/components/myPage/MyActivity.tsx
+++ b/src/components/myPage/MyActivity.tsx
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 import BookIcon from '@/assets/icon/book-icon.svg?react';
 import PointIcon from '@/assets/icon/point-icon.svg?react';
+import useStore from '@/store/store';
 
 function MyActivity() {
+  const { user } = useStore();
   return (
     <Wrapper>
       <h2>나의 활동</h2>
@@ -11,14 +13,14 @@ function MyActivity() {
           <BookIcon />
           <Activity>
             <span>내가 공유한 지식</span>
-            <h4>19개</h4>
+            <h4>{user!.totalPosts}개</h4>
           </Activity>
         </ActivityInfo>
         <ActivityInfo>
           <PointIcon />
           <Activity>
             <span>보유 포인트</span>
-            <h4>204점</h4>
+            <h4>{user!.totalPoints}점</h4>
           </Activity>
         </ActivityInfo>
       </Container>

--- a/src/components/myPage/MyInfo.tsx
+++ b/src/components/myPage/MyInfo.tsx
@@ -7,10 +7,12 @@ import { AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { LOGIN_ROUTER_PATH } from '@/constants/path';
 import useStore from '@/store/store';
+import { TokenKey } from '@/constants/storage';
 
 function MyInfo() {
   const navigate = useNavigate();
-  const { logOut } = useStore();
+  const { logOut, user } = useStore();
+  const clearStorage = useStore.persist.clearStorage;
   const [open, setOpen] = useState<boolean>(false);
 
   // 팝업 등장 시 뒷배경 스크롤 방지
@@ -22,6 +24,8 @@ function MyInfo() {
 
   const handleLogOut = () => {
     logOut();
+    localStorage.removeItem(TokenKey);
+    clearStorage();
     navigate(LOGIN_ROUTER_PATH.login);
   };
 
@@ -32,7 +36,7 @@ function MyInfo() {
         <Content>
           <Info>
             <h4>이름</h4>
-            <span>연하영</span>
+            <span>{user!.nickname}</span>
           </Info>
           <Info>
             <h4>ID</h4>

--- a/src/components/myPage/MyLevel.tsx
+++ b/src/components/myPage/MyLevel.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
-import Lv5 from '@/assets/image/lv5.svg?react';
 import InfoIcon from '@/assets/icon/info-icon.svg?react';
 import { useState } from 'react';
 import LevelPopUp from '../popup/LevelPopUp';
 import { AnimatePresence } from 'framer-motion';
+import { useLevel } from '@/hooks/useLevel';
 
 function MyLevel() {
   const [open, setOpen] = useState<boolean>(false);
+  const { userLevel } = useLevel();
 
   // 팝업 등장 시 뒷배경 스크롤 방지
   if (open) {
@@ -23,10 +24,10 @@ function MyLevel() {
           <InfoIcon />
         </InfoIconWrapper>
         <Content>
-          <Lv5 />
+          <img src={userLevel.icon} alt='level' width={80} height={80} />
           <UserLevel>
-            <h2>Lv.5</h2>
-            <span>개발자에게 밤샘은 기본</span>
+            <h2>{userLevel.level}</h2>
+            <span>{userLevel.name}</span>
           </UserLevel>
         </Content>
       </Container>
@@ -53,7 +54,7 @@ const Container = styled.div`
   border-radius: 12px;
   padding: 16px;
   display: flex;
-  justify-content: center;
+
   align-items: center;
   position: relative;
 `;
@@ -62,6 +63,7 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   gap: 25px;
+  padding: 0 24px;
 `;
 
 const UserLevel = styled.div`

--- a/src/components/popup/DeleteAccountPopUp.tsx
+++ b/src/components/popup/DeleteAccountPopUp.tsx
@@ -3,12 +3,35 @@ import { ICONS } from '@/assets/icon/icons';
 import ActivityBox from './item/ActivityBox';
 import styled from 'styled-components';
 import FormButton from '../common/FormInput/FormButton';
+import { userAPI } from '@/api/userAPI';
+import useStore from '@/store/store';
+import { useNavigate } from 'react-router-dom';
+import { LOGIN_ROUTER_PATH } from '@/constants/path';
+import { TokenKey, UserEmailKey, UserPasswordKey } from '@/constants/storage';
 
 interface Props {
   closePopup: () => void;
 }
 
 function DeleteAccountPopUp({ closePopup }: Props) {
+  const navigate = useNavigate();
+  const { logOut } = useStore();
+  const clearStorage = useStore.persist.clearStorage;
+
+  const handleDelete = async () => {
+    await userAPI.deleteAccount().then((res) => {
+      if (res?.isSuccess) {
+        logOut();
+        clearStorage();
+
+        localStorage.removeItem(UserEmailKey);
+        localStorage.removeItem(UserPasswordKey);
+        localStorage.removeItem(TokenKey);
+
+        navigate(LOGIN_ROUTER_PATH.login);
+      }
+    });
+  };
   return (
     <PopUpLayout
       title='회원 탈퇴'
@@ -22,7 +45,7 @@ function DeleteAccountPopUp({ closePopup }: Props) {
           포함한 모든 데이터가 영구적으로 삭제되며, 삭제된 데이터는 다시 복구할
           수 없습니다.
         </Message>
-        <FormButton text='회원탈퇴' fontSize='14px' onClick={() => {}} />
+        <FormButton text='회원탈퇴' fontSize='14px' onClick={handleDelete} />
       </Wrapper>
     </PopUpLayout>
   );

--- a/src/constants/level.ts
+++ b/src/constants/level.ts
@@ -1,6 +1,16 @@
 const PATH = '/src/assets/level/';
 
-export const LEVEL = {
+export interface LevelType {
+  level: string;
+  icon: string;
+  name: string;
+}
+
+export type LevelKeys = keyof typeof LEVEL;
+
+export const LEVEL: {
+  [key: number]: LevelType;
+} = {
   1: {
     level: 'Lv.1',
     icon: PATH + 'Lv.1.svg',

--- a/src/hooks/useLevel.tsx
+++ b/src/hooks/useLevel.tsx
@@ -1,0 +1,14 @@
+import { LEVEL, LevelKeys, LevelType } from '@/constants/level';
+import useStore from '@/store/store';
+import { useEffect, useState } from 'react';
+
+export const useLevel = () => {
+  const [userLevel, setUserLevel] = useState<LevelType>(LEVEL[1]);
+  const { user } = useStore();
+
+  useEffect(() => {
+    setUserLevel(LEVEL[user?.level as LevelKeys]);
+  }, [user?.level]);
+
+  return { userLevel };
+};

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,3 +1,4 @@
+import { userAPI } from '@/api/userAPI';
 import Banner from '@/components/common/Banner';
 import Category from '@/components/common/Category';
 import Pagination from '@/components/common/Pagination';
@@ -5,11 +6,13 @@ import PostList from '@/components/homePage/PostList';
 import SearchInput from '@/components/homePage/SearchInput';
 import SideBar from '@/components/homePage/SideBar';
 import { Post, postDummy } from '@/data/postDummy';
+import useStore from '@/store/store';
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 function HomePage() {
+  const { setUserInfo } = useStore();
   const page = useSearchParams()[0].get('page');
   const [posts, setPosts] = useState<Post[]>([]);
   const pageNum = page ? +page : 1;
@@ -18,6 +21,15 @@ function HomePage() {
     setPosts(postDummy.slice(21 * (pageNum - 1), 21 * pageNum)); // 임시 (서버 연동 부분)
     window.scroll(0, 0);
   }, [page]);
+
+  useEffect(() => {
+    const getUser = async () => {
+      await userAPI.getUserInfo().then((res) => {
+        setUserInfo(res!.result);
+      });
+    };
+    getUser();
+  }, []);
 
   return (
     <>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -37,7 +37,7 @@ const useStore = create(
             user: userData,
           }));
         },
-        logOut: () => set(() => ({ user: null, accessToken: null })),
+        logOut: () => set(() => ({ user: null })),
       }),
       {
         name: 'store',

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,12 +3,17 @@ import { devtools } from 'zustand/middleware';
 import { persist } from 'zustand/middleware';
 
 interface User {
-  id: string;
+  userId: string;
+  nickname: string;
+  level: number;
+  totalPosts: number;
+  totalPoints: number;
 }
 
 interface Store {
   user: User | null;
-  setUser: (id: string) => void;
+  setUserId: (id: string) => void;
+  setUserInfo: (data: User) => void;
   logOut: () => void;
 }
 
@@ -17,12 +22,21 @@ const useStore = create(
     persist<Store>(
       (set) => ({
         user: null,
-        setUser: (userId: string) =>
+        setUserId: (id: string) =>
           set(() => ({
             user: {
-              id: userId,
+              userId: id,
+              nickname: '',
+              level: 1,
+              totalPoints: 0,
+              totalPosts: 0,
             },
           })),
+        setUserInfo: (userData: User) => {
+          set(() => ({
+            user: userData,
+          }));
+        },
         logOut: () => set(() => ({ user: null, accessToken: null })),
       }),
       {

--- a/src/types/api/request.d.ts
+++ b/src/types/api/request.d.ts
@@ -8,3 +8,8 @@ export interface JoinReq {
   email: string;
   password: string;
 }
+
+export interface RequestResetReq {
+  email: string;
+  nickname: string;
+}

--- a/src/types/api/response.d.ts
+++ b/src/types/api/response.d.ts
@@ -21,3 +21,10 @@ export interface UserInfoRes extends CommonRes {
     totalPoints: number;
   };
 }
+
+export interface TopFiveRes extends CommonRes {
+  id: string;
+  name: string;
+  level: number;
+  points: number;
+}

--- a/src/types/api/response.d.ts
+++ b/src/types/api/response.d.ts
@@ -11,3 +11,13 @@ export interface LoginRes extends CommonRes {
 export interface EmailCheckRes extends CommonRes {
   result?: boolean;
 }
+
+export interface UserInfoRes extends CommonRes {
+  result: {
+    userId: string;
+    nickname: string;
+    level: number;
+    totalPosts: number;
+    totalPoints: number;
+  };
+}


### PR DESCRIPTION
## 📍 작업 내용
- API instance 수정
- 프로필 조회 API 연동
- Top 5 조회 API 연동
- 회원 탈퇴 API 연동
- 비밀번호 찾기/재설정 API 연동
- useLevel 커스텀 훅 (현재 로그인 한 유저의 level 데이터 가져오기)

<br/>

## 📍 구현 결과 (선택)

<br/>

## 📍 기타 사항
- API 폴더 내용 조금 수정했으니 참고 부탁드려요!!

<br/>
