### PR TITLE
[Style/#52]: 중복확인 메시지 위치 수정

### DIFF
--- a/src/components/account/JoinForm.tsx
+++ b/src/components/account/JoinForm.tsx
@@ -72,7 +72,11 @@ const JoinForm = () => {
               id={'name-input'}
               label={'Name'}
               placeholder='닉네임을 입력해주세요 (2~6자)'
-              errorMessage={errors.nickname?.message}
+              successMessage={nameCheck.canUse ? nameCheck.message : ''}
+              errorMessage={
+                errors.nickname?.message ||
+                (nameCheck.canUse ? '' : nameCheck.message)
+              }
               {...register('nickname', {
                 onChange: () => {
                   resetNameStatus();
@@ -94,7 +98,6 @@ const JoinForm = () => {
               {'중복확인'}
             </button>
           </InputWithButton>
-          <Message $isError={!nameCheck.canUse}>{nameCheck.message}</Message>
         </InputWrapper>
         <InputWrapper>
           <InputWithButton>
@@ -103,7 +106,11 @@ const JoinForm = () => {
               id={'email-input'}
               label={'Email'}
               placeholder='이메일을 입력해주세요'
-              errorMessage={errors.email?.message}
+              successMessage={emailCheck.canUse ? emailCheck.message : ''}
+              errorMessage={
+                errors.email?.message ||
+                (emailCheck.canUse ? '' : emailCheck.message)
+              }
               {...register('email', {
                 onChange: () => {
                   resetEmailStatus();
@@ -121,7 +128,6 @@ const JoinForm = () => {
               {'중복확인'}
             </button>
           </InputWithButton>
-          <Message $isError={!emailCheck.canUse}>{emailCheck.message}</Message>
         </InputWrapper>
 
         <FormInput
@@ -191,10 +197,4 @@ const InputWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 6px;
-`;
-
-const Message = styled.span<{ $isError: boolean }>`
-  width: 100%;
-  color: ${({ theme, $isError }) => ($isError ? theme.color_textRed : 'green')};
-  font-size: ${({ theme }) => theme.fontSize_sm};
 `;

--- a/src/components/common/FormInput/FormInput.tsx
+++ b/src/components/common/FormInput/FormInput.tsx
@@ -6,6 +6,7 @@ interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   label: string;
   value?: string;
   errorMessage?: string;
+  successMessage?: string;
   placeholder?: string;
   type?: 'text' | 'password';
   onChange?: ChangeEventHandler<HTMLInputElement>;
@@ -18,6 +19,7 @@ const FormInput = forwardRef<HTMLInputElement, Props>(
       label,
       value,
       errorMessage,
+      successMessage,
       placeholder,
       type = 'text',
       style,
@@ -28,13 +30,19 @@ const FormInput = forwardRef<HTMLInputElement, Props>(
   ) => {
     return (
       <FormInputRoot style={style}>
-        <LabelContainer $isError={Boolean(errorMessage)}>
+        <LabelContainer
+          $isError={Boolean(errorMessage)}
+          $isSuccess={Boolean(successMessage)}>
           <label htmlFor={id} className='label'>
             {label}
           </label>
-          <span className='error-message'>{errorMessage}</span>
+          <span className='message'>
+            {errorMessage ? errorMessage : successMessage ? successMessage : ''}
+          </span>
         </LabelContainer>
-        <InputContainer $isError={Boolean(errorMessage)}>
+        <InputContainer
+          $isError={Boolean(errorMessage)}
+          $isSuccess={Boolean(successMessage)}>
           <input
             className='input'
             ref={ref}
@@ -57,31 +65,31 @@ const FormInputRoot = styled.div`
   max-width: 380px;
 `;
 
-const LabelContainer = styled.div<{ $isError: boolean }>`
+const LabelContainer = styled.div<{ $isError: boolean; $isSuccess: boolean }>`
   height: 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: ${({ theme, $isError }) =>
-    $isError ? theme.color_textRed : theme.color_key};
+  color: ${({ theme, $isError, $isSuccess }) =>
+    $isError ? theme.color_textRed : $isSuccess ? 'green' : theme.color_key};
 
   .label {
     font-size: 14px;
     font-weight: 700;
   }
 
-  .error-message {
-    font-size: 10px;
+  .message {
+    font-size: 11px;
     font-weight: 400;
   }
 `;
 
-const InputContainer = styled.div<{ $isError: boolean }>`
+const InputContainer = styled.div<{ $isError: boolean; $isSuccess: boolean }>`
   width: 100%;
   padding: 10px 0;
   border-bottom: 1px solid
-    ${({ theme, $isError }) =>
-      $isError ? theme.color_textRed : theme.color_key};
+    ${({ theme, $isError, $isSuccess }) =>
+      $isError ? theme.color_textRed : $isSuccess ? 'green' : theme.color_key};
 
   .input {
     font-size: 14px;

--- a/src/components/layouts/AccountLayout.tsx
+++ b/src/components/layouts/AccountLayout.tsx
@@ -89,7 +89,7 @@ const AccountCardTitle = styled.span`
   color: ${({ theme }) => theme.color_textBlack};
   font-weight: 700;
   font-size: 28px;
-  margin-bottom: 24px;
+  margin-bottom: 0px;
 `;
 
 const FormRoot = styled.form`


### PR DESCRIPTION
## 📍 작업 내용
- 닉네임, 이메일 중복확인 메시지 위치 수정
   (오류 메시지, 성공 메시지 모두 같은 위치에 나타나도록 수정했습니다)

<br/>

## 📍 구현 결과 (선택)
<img width="1710" alt="스크린샷 2024-06-16 오후 5 13 04" src="https://github.com/Team-DevHub/dev-hub-front/assets/121474189/82d2559e-c559-4278-9c42-f7ccdbf10771">

<br/>

## 📍 기타 사항

<br/>
