### PR TITLE
[API]: 스크랩 관련 API 재연동

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -32,7 +32,12 @@ authInstance.interceptors.request.use(
   (config) => {
     const { accessToken } = getAccessToken();
 
-    config.headers['Authorization'] = `Bearer ${accessToken}`;
+    if (accessToken) {
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
+    } else {
+      config.headers['Authorization'] = ''; // accessToken이 null인 경우 빈값으로 설정
+    }
+
     return config;
   },
   (error) => {

--- a/src/api/requests/postAPI.ts
+++ b/src/api/requests/postAPI.ts
@@ -4,7 +4,6 @@ import { API_ERROR_MSG } from '@/constants/message';
 import {
   CommentReq,
   PostRes,
-  PostSummary,
   PostingReq,
   PostsReq,
   PostsRes,
@@ -27,7 +26,7 @@ export const postAPI = {
   },
   posts: async (params: PostsReq) => {
     try {
-      const myPage = params.myPage === true;
+      const myPage = params.myPage || params.scrap === true;
       const instance = myPage ? authInstance : baseInstance;
 
       const { data }: AxiosResponse = await instance.get<PostsRes>(`/posts`, {
@@ -127,16 +126,6 @@ export const postAPI = {
     try {
       const { data }: AxiosResponse<CommonRes> = await authInstance.delete(
         `posts/${postId}/scrap`,
-      );
-      return data;
-    } catch (err) {
-      window.alert(API_ERROR_MSG);
-    }
-  },
-  myscrap: async () => {
-    try {
-      const { data }: AxiosResponse = await authInstance.get<PostSummary>(
-        `/scrap`,
       );
       return data;
     } catch (err) {

--- a/src/api/requests/postAPI.ts
+++ b/src/api/requests/postAPI.ts
@@ -115,8 +115,8 @@ export const postAPI = {
   },
   scrap: async (postId: number) => {
     try {
-      const { data }: AxiosResponse<CommonRes> = await authInstance.get(
-        `/scrap/${postId}`,
+      const { data }: AxiosResponse<CommonRes> = await authInstance.post(
+        `posts/${postId}/scrap`,
       );
       return data;
     } catch (err) {
@@ -126,7 +126,7 @@ export const postAPI = {
   unscrap: async (postId: number) => {
     try {
       const { data }: AxiosResponse<CommonRes> = await authInstance.delete(
-        `/scrap/${postId}`,
+        `posts/${postId}/scrap`,
       );
       return data;
     } catch (err) {

--- a/src/api/requests/postAPI.ts
+++ b/src/api/requests/postAPI.ts
@@ -52,7 +52,7 @@ export const postAPI = {
   },
   post: async (postId: number) => {
     try {
-      const { data }: AxiosResponse = await baseInstance.get<PostRes>(
+      const { data }: AxiosResponse = await authInstance.get<PostRes>(
         `/posts/${postId}`,
       );
       return data;

--- a/src/components/modal/PostDetail.tsx
+++ b/src/components/modal/PostDetail.tsx
@@ -38,16 +38,18 @@ function PostDetail() {
       <Container>
         <TopBar>
           <Tag>{getCategoryName(selectedPost.categoryId)}</Tag>
-          <img
-            src={
-              selectedPost.isScrapped
-                ? ICONS.scrap.active
-                : ICONS.scrap.inactive
-            }
-            alt='scrap'
-            className='scrap'
-            onClick={toggleScrap}
-          />
+          {selectedPost.isScrapped !== null && (
+            <img
+              src={
+                selectedPost.isScrapped
+                  ? ICONS.scrap.active
+                  : ICONS.scrap.inactive
+              }
+              alt='scrap'
+              className='scrap'
+              onClick={toggleScrap}
+            />
+          )}
           <UserInfo>
             <span>Lv.{selectedPost.writer.level}</span>
             <h4>{selectedPost.writer.nickname}</h4>

--- a/src/hooks/useMyPosts.ts
+++ b/src/hooks/useMyPosts.ts
@@ -42,7 +42,7 @@ export const useMyPosts = () => {
   const { data: myScraps } = useQuery<PostSummary[]>({
     queryKey: ['myScraps'],
     queryFn: async () => {
-      const response = await postAPI.myscrap();
+      const response = await postAPI.posts({ scrap: true });
       return response.result || [];
     },
   });

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -11,7 +11,7 @@ export interface PostsReq {
   limit?: number;
   page?: number;
   myPage?: boolean;
-  scrape?: boolean;
+  scrap?: boolean;
   search?: string;
   categoryId?: number;
 }

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -11,6 +11,7 @@ export interface PostsReq {
   limit?: number;
   page?: number;
   myPage?: boolean;
+  scrape?: boolean;
   search?: string;
   categoryId?: number;
 }

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -39,8 +39,8 @@ export interface Post {
   totalComments: number;
   writer: Writer;
   createdAt: string;
-  comments: Comment[];
   isScrapped: boolean;
+  comments: Comment[];
 }
 
 export interface Comment {


### PR DESCRIPTION
## 📍 작업 내용

- 스크랩 API 엔드포인트 경로 수정
- 게시글 상세 조회 API 수정
- 비회원 게시글 상세 조회 시 스크랩 버튼 없애기
- 게시글 스크랩 리스트 조회 API 변경

<br/>

## 📍 구현 결과 (선택)
- 비회원으로 게시글 상세 조회
![image](https://github.com/user-attachments/assets/482f3ca4-7986-40c0-9d36-8ede6263df2c)

- 회원으로 게시글 상세 조회 
![image](https://github.com/user-attachments/assets/3b521181-cc4e-4ed0-bfb6-0f658916395f)

<br/>

## 📍 기타 사항



<br/>
